### PR TITLE
Lighten namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Allows:
 The example in source/main.c displays an image as background on the client screen after multiboot, and GBAs can then interact with each other upon pressing A button.
 
 TODO: add a decent HOW_TO
+
+
+## CHANGELOG
+
+- 2023/12/01:
+  - minor changes in internal functions, reduce wait between comms in normal mode
+- 2023/09/29:
+  - initial release

--- a/source/communication.c
+++ b/source/communication.c
@@ -4,6 +4,13 @@
 #include "logging.h"
 #include "communication.h"
 
+static bool comm_is_parent() { return !isSIOCNTBitHigh(COMM_SIOCNT_SITERMINAL_BIT); }
+
+
+int comm_get_multiplayer_id()
+{
+    return (REG_SIOCNT>>4) & 0b11;
+}
 
 enum OperationStatus comm_init(CancelFunc isCanceled)
 {
@@ -60,10 +67,6 @@ MultiplayData comm_exchange(u16 data, CancelFunc isCanceled)
 }
 
 
-int comm_get_multiplayer_id()
-{
-    return (REG_SIOCNT>>4) & 0b11;
-}
 
 
 enum OperationStatus comm_init_normal(bool leader)
@@ -120,4 +123,3 @@ u32 comm_exchange_normal(u32 data, bool leader, CancelFunc isCanceled)
 }
 
 
-bool comm_is_parent() { return !isSIOCNTBitHigh(COMM_SIOCNT_SITERMINAL_BIT); }

--- a/source/communication.c
+++ b/source/communication.c
@@ -89,8 +89,6 @@ u32 comm_exchange_normal(u32 data, bool leader, CancelFunc isCanceled)
 
     if (leader)
     {
-        wait_sync(COMM_WAIT_BEFORE_TRANSFER);
-
         // wait for release of start bit
         while (isSIOCNTBitHigh(COMM_SIOCNT_NORMAL_SI_BIT))
         { RETURN_IF_CANCELED(isCanceled, received_data); }

--- a/source/communication.h
+++ b/source/communication.h
@@ -17,7 +17,6 @@ typedef struct {
 enum OperationStatus comm_init(CancelFunc isCanceled);
 MultiplayData comm_exchange(u16 data, CancelFunc isCanceled);
 int comm_get_multiplayer_id();
-bool comm_is_parent();
 enum OperationStatus comm_init_normal(bool leader);
 u32 comm_exchange_normal(u32 data, bool leader, CancelFunc isCanceled);
 

--- a/source/multiboot.h
+++ b/source/multiboot.h
@@ -49,13 +49,5 @@ typedef struct {
 
 bool is_booted_from_multiboot();
 enum OperationStatus startMultiBoot(const void* rom, u32 romSize, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus detect_clients(MultiBootParam *multibootParameters, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus confirm_clients(MultiBootParam *multibootParameters, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus send_header(const void* rom, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus complete_header_sending(MultiBootParam *multibootParameters, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus send_palette(MultiBootParam *multibootParameters, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-enum OperationStatus confirm_handshake(MultiBootParam *multibootParameters, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
-
-Responses multiboot_exchange(u16 data, enum MultiplayerSessionMode sessionMode, CancelFunc isCanceled);
 
 #endif


### PR DESCRIPTION
- removed unnecessary wait before communication in NORMAL mode
- changed some functions to static, in order to lighten the namespace after import